### PR TITLE
修复bug：权限检查错误导致非管理员用户无法创建装扮

### DIFF
--- a/src/Api/Controller/AddUserDecoration.php
+++ b/src/Api/Controller/AddUserDecoration.php
@@ -26,7 +26,7 @@ class AddUserDecoration extends AbstractShowController
     protected function data(Request $request, Document $document)
     {
         $actor = RequestUtil::getActor($request);
-        $actor->assertCan('create_decoration');
+        $actor->assertCan('user.create_decoration');
         $attributes = Arr::get($request->getParsedBody(), 'attributes', []);
         if (Arr::get($attributes, 'id')) {
             $newModel = UserDecoration::findOrFail(Arr::get($attributes, 'id'));

--- a/src/Api/Controller/AddUserOwnDecoration.php
+++ b/src/Api/Controller/AddUserOwnDecoration.php
@@ -27,7 +27,7 @@ class AddUserOwnDecoration extends AbstractCreateController
     protected function data(Request $request, Document $document)
     {
         $actor = RequestUtil::getActor($request);
-        $actor->assertCan('offer_decoration');
+        $actor->assertCan('user.offer_decoration');
         
         $attributes = Arr::get($request->getParsedBody(), 'attributes', []);
         $newModel = new UserOwnDecoration();

--- a/src/Api/Controller/DeleteUserDecoration.php
+++ b/src/Api/Controller/DeleteUserDecoration.php
@@ -31,7 +31,7 @@ class DeleteUserDecoration extends AbstractDeleteController
         $actor = RequestUtil::getActor($request);
         $id = Arr::get($request->getQueryParams(), 'id');
         $model = UserDecoration::findOrFail($id);
-        $actor->assertCan("create_decoration");
+        $actor->assertCan("user.create_decoration");
         $model->delete();
     }
 }

--- a/src/Api/Controller/DeleteUserOwnDecoration.php
+++ b/src/Api/Controller/DeleteUserOwnDecoration.php
@@ -30,7 +30,7 @@ class DeleteUserOwnDecoration extends AbstractDeleteController
         $id = Arr::get($request->getQueryParams(), 'id');
         $model = UserOwnDecoration::findOrFail($id);
         if ($model->user_id != $actor->id) {
-            $actor->assertCan("delete_decoration");
+            $actor->assertCan("user.delete_decoration");
         }
 
         $user = User::findOrFail($model->user_id);

--- a/src/Api/Serializer/UserAttributeSerializer.php
+++ b/src/Api/Serializer/UserAttributeSerializer.php
@@ -17,9 +17,9 @@ class UserAttributeSerializer
 
     public function __invoke($serializer, $user, $attributes)
     {
-        $attributes['canOfferDecoration'] = $serializer->getActor()->can('offer_decoration');
-        $attributes['canCreateDecoration'] = $serializer->getActor()->can('create_decoration');
-        $attributes['canDeleteDecoration'] = $serializer->getActor()->can('delete_decoration');
+        $attributes['canOfferDecoration'] = $serializer->getActor()->can('user.offer_decoration');
+        $attributes['canCreateDecoration'] = $serializer->getActor()->can('user.create_decoration');
+        $attributes['canDeleteDecoration'] = $serializer->getActor()->can('user.delete_decoration');
         return $attributes;
     }
 }


### PR DESCRIPTION
# 问题描述：
## 预期行为：
在 Flarum 后台的“权限”设置中，当“注册用户”组被授予“创建/编辑装扮”的权限后，任何注册用户都应该能在自己的个人主页 -> “装扮”页面看到“创建”按钮。

## 实际行为：
只有管理员能看到“创建”按钮。被授予权限的普通注册用户无法看到该按钮，因此无法使用此功能。

## 分析
后端代码在检查用户权限时，使用的权限名称字符串与前端 js/src/admin/index.ts 中定义的权限名称不一致。

在 js/src/admin/index.ts 中，权限被正确地定义为 user.create_decoration、user.offer_decoration 等，带有 user. 前缀。

在 src/Api/Serializer/UserAttributeSerializer.php 中，权限检查的代码是 $serializer->getActor()->can('create_decoration')，缺少了 user. 前缀。

这个不匹配导致了权限检查对非管理员用户失败，因为他们没有一个叫做 create_decoration 的权限。管理员用户可能因为拥有全局权限而绕过了这个检查。

## 解决：
```
namespace Xypp\UserDecoration\Api\Serializer;

class UserAttributeSerializer
{
    public function __invoke($serializer, $user, $attributes)
    {
        // 为权限检查添加正确的 "user." 前缀
        $attributes['canOfferDecoration'] = $serializer->getActor()->can('user.offer_decoration');
        $attributes['canCreateDecoration'] = $serializer->getActor()->can('user.create_decoration');
        $attributes['canDeleteDecoration'] = $serializer->getActor()->can('user.delete_decoration');

        return $attributes;
    }
}